### PR TITLE
Fix Cannot read properties of null (reading 'length') on Chrome Mobile/Samsung browsers

### DIFF
--- a/src/components/R64Input.vue
+++ b/src/components/R64Input.vue
@@ -145,7 +145,7 @@ export default {
     },
 
     onInput() {
-      this.hasInput = this.localValue.length
+      this.hasInput = this.localValue ? this.localValue.length : false
     },
 
     onKeyUp(event) {


### PR DESCRIPTION
Hey @pepeloper we're seeing multiple JS errors on Android devices when `localValue` is set to null and `onInput` is triggered. This should fix errors coming from these devices.